### PR TITLE
ci: fix pull_req時にAPI diffの実行ができない (#12123)

### DIFF
--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -1,4 +1,5 @@
-name: Report API Diff
+# this name is used in report-api-diff.yml so be careful when change name
+name: Get api.json from Misskey
 
 on:
   pull_request:
@@ -170,56 +171,3 @@ jobs:
         path: api-head.json
     - name: Kill Misskey Job
       run: screen -S misskey -X quit
-
-  compare-diff:
-    runs-on: ubuntu-latest
-    if: success()
-    needs: [get-base, get-head]
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: api-artifact
-          path: ./artifacts
-      - name: Output base
-        run: cat ./artifacts/api-base.json
-      - name: Output head
-        run: cat ./artifacts/api-head.json
-      - name: Arrange json files
-        run: |
-          jq '.' ./artifacts/api-base.json > ./api-base.json
-          jq '.' ./artifacts/api-head.json > ./api-head.json
-      - name: Get diff of 2 files
-        run: diff -u --label=base --label=head ./api-base.json ./api-head.json | cat > api.json.diff
-      - name: Get full diff
-        run: diff --label=base --label=head --new-line-format='+%L' --old-line-format='-%L' --unchanged-line-format=' %L' ./api-base.json ./api-head.json | cat > api-full.json.diff
-      - name: Echo full diff
-        run: cat ./api-full.json.diff
-      - name: Upload full diff to Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: api-artifact
-          path: api-full.json.diff
-      - id: out-diff
-        name: Build diff Comment
-        run: |
-          cat <<- EOF > ./output.md
-          このPRによるapi.jsonの差分
-          <details>
-          <summary>差分はこちら</summary>
-
-          \`\`\`diff
-          $(cat ./api.json.diff)
-          \`\`\`
-          </details>
-
-          [Get diff files from Workflow Page](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
-          EOF
-      - name: Write diff comment
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          comment_tag: show_diff
-          filePath: ./output.md

--- a/.github/workflows/report-api-diff.yml
+++ b/.github/workflows/report-api-diff.yml
@@ -1,0 +1,92 @@
+name: Report API Diff
+
+on:
+  workflow_run:
+    types: [completed]
+    workflows:
+      - Get api.json from Misskey # get-api-diff.yml
+
+jobs:
+  compare-diff:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      pull-requests: write
+
+# api-artifact
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "api-artifact"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/api-artifact.zip`, Buffer.from(download.data));
+      - name: Extract artifact
+        run: unzip api-artifact.zip -d artifacts
+      - name: Load PR Number
+        id: load-pr-num
+        env:
+          PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests.*) }}
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          # find first pull requests that targets this repository
+          PR_NUMBER="$(echo "$PULL_REQUESTS" \
+              | jq --arg REPO_ID "$REPO_ID" '[.[] | select ($REPO_ID == (.base.repo.id | tostring)) | .number ][0]')"
+          echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Output base
+        run: cat ./artifacts/api-base.json
+      - name: Output head
+        run: cat ./artifacts/api-head.json
+      - name: Arrange json files
+        run: |
+          jq '.' ./artifacts/api-base.json > ./api-base.json
+          jq '.' ./artifacts/api-head.json > ./api-head.json
+      - name: Get diff of 2 files
+        run: diff -u --label=base --label=head ./api-base.json ./api-head.json | cat > api.json.diff
+      - name: Get full diff
+        run: diff --label=base --label=head --new-line-format='+%L' --old-line-format='-%L' --unchanged-line-format=' %L' ./api-base.json ./api-head.json | cat > api-full.json.diff
+      - name: Echo full diff
+        run: cat ./api-full.json.diff
+      - name: Upload full diff to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: api-artifact
+          path: |
+            api-full.json.diff
+            api-base.json
+            api-head.json
+      - id: out-diff
+        name: Build diff Comment
+        run: |
+          cat <<- EOF > ./output.md
+          このPRによるapi.jsonの差分
+          <details>
+          <summary>差分はこちら</summary>
+
+          \`\`\`diff
+          $(cat ./api.json.diff)
+          \`\`\`
+          </details>
+
+          [Get diff files from Workflow Page](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+          EOF
+      - uses: thollander/actions-comment-pull-request@v2
+        with:
+          pr_number: ${{ steps.load-pr-num.outputs.pr-number }}
+          comment_tag: show_diff
+          filePath: ./output.md


### PR DESCRIPTION
* initial commit for report-api-diff.yml

* add api-{base,head}.json into api-artifact

* try to get pull request id from github.event.workflow_run.pull_requests

* Update report-api-diff.yml

* Update report-api-diff.yml

* remove save-pr-number